### PR TITLE
2-step initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The following methods can be called by anyone:
 - `ERC677BridgeToken` public methods (`transferAndCall`, `transfer`, `transferFrom`, `approve`, `increaseAllowance`, `decreaseAllowance`);
 - `Distribution.unlockRewardForStaking` to transfer part of tokens to the bridge contract;
 - `Distribution.makeInstallment` to transfer weekly installment to specified pool;
-- `Distribution.initialize` (if 90 days after pre-initialization are expired) to initialize the `Distribution` and `PrivateOfferingDistribution` contracts;
+- `Distribution.initialize` (if 90 days after pre-initialization are expired) to initialize the `Distribution` and `PrivateOfferingDistribution` contracts.
 
 ### Private Offering participant
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ The `finalizeParticipants` function will add `address(0)` to the participant set
 
 4. Deploy the `ERC677BridgeToken` contract (and pass `Distribution` and `PrivateOfferingDistribution` contracts addresses to the constructor).
 
-5. Call `initialize` function of the `Distribution` contract with `ERC677BridgeToken` address as a parameter. It releases Public Offering, Exchange Related Activities, and 25% of Private Offering tokens. The countdown for cliff periods and installments starts from this moment.
+5. Call `preInitialize` function of the `Distribution` contract with `ERC677BridgeToken` address as a parameter. It releases Public Offering and Exchange Related Activities tokens.
+
+6. Call `initialize` function of the `Distribution` contract. It releases 25% of Private Offering tokens, and the countdown for cliff periods and installments starts from this moment.
 
 ### Test deployment and initialization (Kovan)
 Run your local node.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ The owner is supposed to be a MultiSig Wallet contract. The owner can only call 
 - `ERC677BridgeToken.claimTokens` to transfer coins or specified tokens to the specified address if someone sent coins/tokens to the contract mistakenly;
 - `Distribution.transferOwnership` to transfer ownership of the `Distribution` contract to another address;
 - `Distribution.renounceOwnership` to leave the `Distribution` contract without owner;
-- `Distribution.initialize` to initialize `Distribution` and `PrivateOfferingDistribution` contracts;
+- `Distribution.preInitialize` to pre-initialize the `Distribution` contract (unlock tokens for `Public Offering` and `Exchange Related Activities`);
+- `Distribution.initialize` to initialize the `Distribution` and `PrivateOfferingDistribution` contracts;
 - `Distribution.setBridgeAddress` to set the address of bridge contract to use the address in the `Distribution.unlockRewardForStaking` function;
 - `PrivateOfferingDistribution.transferOwnership` to transfer ownership of the `PrivateOfferingDistribution` contract to another address;
 - `PrivateOfferingDistribution.addParticipants` to add Private Offering participants before initializing;
@@ -66,7 +67,8 @@ The following methods can be called by anyone:
 
 - `ERC677BridgeToken` public methods (`transferAndCall`, `transfer`, `transferFrom`, `approve`, `increaseAllowance`, `decreaseAllowance`);
 - `Distribution.unlockRewardForStaking` to transfer part of tokens to the bridge contract;
-- `Distribution.makeInstallment` to transfer weekly installment to specified pool.
+- `Distribution.makeInstallment` to transfer weekly installment to specified pool;
+- `Distribution.initialize` (if 90 days after pre-initialization are expired) to initialize the `Distribution` and `PrivateOfferingDistribution` contracts;
 
 ### Private Offering participant
 

--- a/contracts/Distribution.sol
+++ b/contracts/Distribution.sol
@@ -12,10 +12,14 @@ contract Distribution is Ownable, IDistribution {
     using SafeMath for uint256;
     using Address for address;
 
-    /// @dev Emits when initialize method has been called
+    /// @dev Emits when preInitialize method has been called
     /// @param token The address of ERC677BridgeToken
     /// @param caller The address of the caller
-    event Initialized(address token, address caller);
+    event PreInitialized(address token, address caller);
+
+    /// @dev Emits when initialize method has been called
+    /// @param caller The address of the caller
+    event Initialized(address caller);
 
     /// @dev Emits when Reward for Staking has been unlocked
     /// @param bridge The address of the bridge contract
@@ -82,6 +86,10 @@ contract Distribution is Ownable, IDistribution {
     /// @dev Duration of staking epoch (in seconds)
     uint256 public stakingEpochDuration;
 
+    /// @dev The timestamp of pre-initialization
+    uint256 public preInitializationTimestamp;
+    /// @dev Boolean variable that indicates whether the contract was pre-initialized
+    bool public isPreInitialized = false;
     /// @dev Boolean variable that indicates whether the contract was initialized
     bool public isInitialized = false;
 
@@ -185,34 +193,49 @@ contract Distribution is Ownable, IDistribution {
 
     }
 
-    /// @dev Initializes the contract after the token is created
+    /// @dev Pre-initializes the contract after the token is created.
+    /// Distributes tokens for Public Offering
     /// @param _tokenAddress The address of the DPOS token
-    function initialize(
-        address _tokenAddress
-    ) external onlyOwner {
-        require(!isInitialized, "already initialized");
+    function preInitialize(address _tokenAddress) external onlyOwner {
+        require(!isPreInitialized, "already pre-initialized");
 
         token = IERC677BridgeToken(_tokenAddress);
         uint256 balance = token.balanceOf(address(this));
         require(balance == supply, "wrong contract balance");
 
-        IPrivateOfferingDistribution(poolAddress[PRIVATE_OFFERING]).initialize(_tokenAddress);
-
-        distributionStartTimestamp = block.timestamp; // solium-disable-line security/no-block-members
-        isInitialized = true;
+        preInitializationTimestamp = now; // solium-disable-line security/no-block-members
+        isPreInitialized = true;
 
         token.transferDistribution(poolAddress[PUBLIC_OFFERING], stake[PUBLIC_OFFERING]);                           // 100%
         token.transferDistribution(poolAddress[EXCHANGE_RELATED_ACTIVITIES], stake[EXCHANGE_RELATED_ACTIVITIES]);   // 100%
-        uint256 privateOfferingPrerelease = stake[PRIVATE_OFFERING].mul(25).div(100);
-        token.transfer(poolAddress[PRIVATE_OFFERING], privateOfferingPrerelease);                                   // 25%
 
         tokensLeft[PUBLIC_OFFERING] = tokensLeft[PUBLIC_OFFERING].sub(stake[PUBLIC_OFFERING]);
         tokensLeft[EXCHANGE_RELATED_ACTIVITIES] = tokensLeft[EXCHANGE_RELATED_ACTIVITIES].sub(stake[EXCHANGE_RELATED_ACTIVITIES]);
-        tokensLeft[PRIVATE_OFFERING] = tokensLeft[PRIVATE_OFFERING].sub(privateOfferingPrerelease);
 
-        emit Initialized(_tokenAddress, msg.sender);
+        emit PreInitialized(_tokenAddress, msg.sender);
         emit InstallmentMade(PUBLIC_OFFERING, stake[PUBLIC_OFFERING], msg.sender);
         emit InstallmentMade(EXCHANGE_RELATED_ACTIVITIES, stake[EXCHANGE_RELATED_ACTIVITIES], msg.sender);
+    }
+
+    /// @dev Initializes token distribution
+    function initialize() external {
+        require(isPreInitialized, "not pre-initialized");
+        require(!isInitialized, "already initialized");
+
+        if (now.sub(preInitializationTimestamp) < 90 days) { // solium-disable-line security/no-block-members
+            require(isOwner(), "for now only owner can call this method");
+        }
+
+        IPrivateOfferingDistribution(poolAddress[PRIVATE_OFFERING]).initialize(address(token));
+
+        distributionStartTimestamp = now; // solium-disable-line security/no-block-members
+        isInitialized = true;
+
+        uint256 privateOfferingPrerelease = stake[PRIVATE_OFFERING].mul(25).div(100);
+        token.transfer(poolAddress[PRIVATE_OFFERING], privateOfferingPrerelease);       // 25%
+        tokensLeft[PRIVATE_OFFERING] = tokensLeft[PRIVATE_OFFERING].sub(privateOfferingPrerelease);
+
+        emit Initialized(msg.sender);
         emit InstallmentMade(PRIVATE_OFFERING, privateOfferingPrerelease, msg.sender);
     }
 

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -46,7 +46,8 @@ module.exports = async deployer => {
     privateOfferingDistribution.address
   );
 
-  // await distribution.initialize(token.address);
+  // await distribution.preInitialize(token.address);
+  // await distribution.initialize();
 };
 
 

--- a/test/distribution.installments.test.js
+++ b/test/distribution.installments.test.js
@@ -82,7 +82,8 @@ contract('Distribution', async accounts => {
             distribution = await createDistribution(privateOfferingDistribution.address);
             token = await createToken(distribution.address, privateOfferingDistribution.address);
             await privateOfferingDistribution.setDistributionAddress(distribution.address);
-            await distribution.initialize(token.address).should.be.fulfilled;
+            await distribution.preInitialize(token.address).should.be.fulfilled;
+            await distribution.initialize().should.be.fulfilled;
         });
         async function makeAllInstallments(pool, epochsPastFromCliff = new BN(0)) {
             let prepaymentValue = new BN(0);
@@ -203,8 +204,9 @@ contract('Distribution', async accounts => {
             distribution = await createDistribution(privateOfferingDistribution.address);
             token = await createToken(distribution.address, privateOfferingDistribution.address);
             await privateOfferingDistribution.setDistributionAddress(distribution.address);
+            await distribution.preInitialize(token.address).should.be.fulfilled;
             await distribution.makeInstallment(PRIVATE_OFFERING).should.be.rejectedWith('not initialized');
-            await distribution.initialize(token.address).should.be.fulfilled;
+            await distribution.initialize().should.be.fulfilled;
             const distributionStartTimestamp = await distribution.distributionStartTimestamp();
             const nextTimestamp = distributionStartTimestamp.add(cliff[PRIVATE_OFFERING]).toNumber();
             await mineBlock(nextTimestamp);


### PR DESCRIPTION
Divide initialization into 2 steps:
1. `preInitialize` - distributes tokens for Public Offering and Exchange Related Activities (who can call: only owner).
2. `initialize` - starts distribution for other pools as it was before (who can call: only owner, and after 90 days - anyone)