### PR TITLE
Call transfer after subtraction

### DIFF
--- a/contracts/PrivateOfferingDistribution.sol
+++ b/contracts/PrivateOfferingDistribution.sol
@@ -160,8 +160,8 @@ contract PrivateOfferingDistribution is Ownable, IPrivateOfferingDistribution {
         uint256 currentShare = maxShareForCurrentEpoch.sub(paidAmount[_recipient]);
         require(currentShare > 0, "no tokens available to withdraw");
 
-        token.transferDistribution(_recipient, currentShare);
         paidAmount[_recipient] = paidAmount[_recipient].add(currentShare);
+        token.transferDistribution(_recipient, currentShare);
 
         return currentShare;
     }


### PR DESCRIPTION
From auditors:
>   In `PrivateOfferingDistribution._withdraw()`, we recommend moving `token.transferDistribution(_recipient, currentShare);` below the following line to adhere to the checks-effects-interactions pattern.